### PR TITLE
Feat/accepts rubocop options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-changes (0.3.0)
+    rubocop-changes (0.4.0)
       git_diff_parser (~> 3.2)
       rubocop (~> 0.80)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    ast (2.4.2)
     byebug (10.0.2)
     diff-lcs (1.3)
     git_diff_parser (3.2.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.1.0)
-      ast (~> 2.4.0)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
     rexml (3.2.5)
@@ -54,4 +54,4 @@ DEPENDENCIES
   rubocop-changes!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/exe/rubocop-changes
+++ b/exe/rubocop-changes
@@ -11,7 +11,8 @@ args = Rubocop::Changes::Options.new.parse!
 offenses = Rubocop::Changes::Checker.new(
   format: args.format,
   quiet: args.quiet,
-  commit: args.commit
+  commit: args.commit,
+  auto_correct: args.auto_correct
 ).run
 
 exit offenses.count.positive? ? 1 : 0

--- a/lib/rubocop/changes/checker.rb
+++ b/lib/rubocop/changes/checker.rb
@@ -13,10 +13,11 @@ module Rubocop
     class UnknownForkPointError < StandardError; end
 
     class Checker
-      def initialize(format:, quiet:, commit:)
+      def initialize(format:, quiet:, commit:, auto_correct:)
         @format = format
         @quiet = quiet
         @commit = commit
+        @auto_correct = auto_correct
       end
 
       def run
@@ -30,7 +31,7 @@ module Rubocop
 
       private
 
-      attr_reader :format, :quiet, :commit
+      attr_reader :format, :quiet, :commit, :auto_correct
 
       def fork_point
         @fork_point ||= Shell.run(command)
@@ -59,7 +60,24 @@ module Rubocop
       end
 
       def rubocop
-        Shell.run("rubocop --force-exclusion -f j #{ruby_changed_files.join(' ')}")
+        shell_command = ['rubocop']
+        shell_command << exclussion_modifier
+        shell_command << formatter_modifier
+        shell_command << auto_correct_modifier
+
+        Shell.run(shell_command.join(' '))
+      end
+
+      def exclussion_modifier
+        ['--force-exclusion']
+      end
+
+      def formatter_modifier
+        ["-f j #{ruby_changed_files.join(' ')}"]
+      end
+
+      def auto_correct_modifier
+        ['-a'] if @auto_correct
       end
 
       def rubocop_json

--- a/lib/rubocop/changes/checker.rb
+++ b/lib/rubocop/changes/checker.rb
@@ -60,24 +60,26 @@ module Rubocop
       end
 
       def rubocop
-        shell_command = ['rubocop']
-        shell_command << exclussion_modifier
-        shell_command << formatter_modifier
-        shell_command << auto_correct_modifier
+        shell_command = [
+          'rubocop',
+          exclussion_modifier,
+          formatter_modifier,
+          auto_correct_modifier
+        ].compact.join(' ')
 
-        Shell.run(shell_command.compact.join(' '))
+        Shell.run(shell_command)
       end
 
       def exclussion_modifier
-        ['--force-exclusion']
+        '--force-exclusion'
       end
 
       def formatter_modifier
-        ["-f j #{ruby_changed_files.join(' ')}"]
+        "-f j #{ruby_changed_files.join(' ')}"
       end
 
       def auto_correct_modifier
-        ['-a'] if @auto_correct
+        '-a' if @auto_correct
       end
 
       def rubocop_json

--- a/lib/rubocop/changes/checker.rb
+++ b/lib/rubocop/changes/checker.rb
@@ -65,7 +65,7 @@ module Rubocop
         shell_command << formatter_modifier
         shell_command << auto_correct_modifier
 
-        Shell.run(shell_command.join(' '))
+        Shell.run(shell_command.compact.join(' '))
       end
 
       def exclussion_modifier

--- a/lib/rubocop/changes/options.rb
+++ b/lib/rubocop/changes/options.rb
@@ -5,10 +5,10 @@ require 'optparse'
 module Rubocop
   module Changes
     class Options
-      Options = Struct.new(:format, :quiet, :commit)
+      Options = Struct.new(:format, :quiet, :commit, :auto_correct)
 
       def initialize
-        @args = Options.new(:simple, false, nil) # Defaults
+        @args = Options.new(:simple, false, nil, false) # Defaults
       end
 
       def parse!
@@ -18,6 +18,7 @@ module Rubocop
           parse_formatter!(opts)
           parse_commit!(opts)
           parse_quiet!(opts)
+          parse_auto_correct!(opts)
           parse_help!(opts)
           parse_version!(opts)
         end.parse!
@@ -61,6 +62,12 @@ module Rubocop
       def parse_quiet!(opts)
         opts.on('-q', '--quiet', 'Be quiet') do |v|
           args.quiet = v
+        end
+      end
+
+      def parse_auto_correct!(opts)
+        opts.on('-a', '--auto-correct', 'Auto correct errors') do |v|
+          args.auto_correct = v
         end
       end
 

--- a/lib/rubocop/changes/version.rb
+++ b/lib/rubocop/changes/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Changes
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end


### PR DESCRIPTION
What?
Accepts a new argument -a that will send to rubocop the auto-fix/auto-correct flag

Why?
It makes it easier to fix errors in one single step

Usage:
`bundle exec rubocop-changes -a`
`bundle exec rubocop-changes --auto-correct`