### PR TITLE
Fix uninitialized constant Rubocop::Changes::Checker::OpenStruct (NameError)

### DIFF
--- a/lib/rubocop/changes/checker.rb
+++ b/lib/rubocop/changes/checker.rb
@@ -3,6 +3,7 @@
 require 'git_diff_parser'
 require 'rubocop'
 require 'json'
+require 'ostruct'
 
 require 'rubocop/changes/check'
 require 'rubocop/changes/shell'


### PR DESCRIPTION
When running `rubocop-changes -b main` you can get an error like this:
```
/usr/local/bundle/gems/rubocop-changes-0.8.1/lib/rubocop/changes/checker.rb:104:in `rubocop_json': uninitialized constant Rubocop::Changes::Checker::OpenStruct (NameError)

        @rubocop_json ||= JSON.parse(rubocop, object_class: OpenStruct)
```